### PR TITLE
Adicionado Formatters compostos

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -174,6 +174,11 @@ class FormattersState extends State<Formatters> {
               formatter: PesoInputFormatter(),
               controller: null,
             ),
+            LinhaFormatter(
+              text: 'CPF/CPNJ',
+              formatter: CPFToCNPJFormatter(),
+              controller: null,
+            ),
           ],
         ),
       ),

--- a/lib/brasil_fields.dart
+++ b/lib/brasil_fields.dart
@@ -16,3 +16,5 @@ export 'modelos/meses.dart';
 export 'modelos/regioes.dart';
 export 'modelos/semana.dart';
 export 'util/util_data.dart';
+export 'compound_formatters/cpf_to_cpnj_formatter.dart';
+export 'compound_formatters/compound_formatter.dart';

--- a/lib/compound_formatters/compound_formatter.dart
+++ b/lib/compound_formatters/compound_formatter.dart
@@ -1,0 +1,30 @@
+import 'package:brasil_fields/interfaces/compoundable_formatter.dart';
+import 'package:flutter/services.dart';
+
+/// Combines two or more [Formatter] instances such that
+/// it's possible to interpolate from the actual to the next
+class CompoundFormatter extends TextInputFormatter {
+  /// Stores a series of [CompoundableFormatter] instances which are chained
+  /// in the same order as they are positioned in the List
+  final List<CompoundableFormatter> _formatters;
+
+  CompoundFormatter(this._formatters)
+      : assert(_formatters != null),
+        assert(_formatters.isNotEmpty),
+        assert(_formatters.length > 1);
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final delegatedFormatter = _formatters.firstWhere((formatter) {
+      final newValueLength = newValue.text.length;
+      final maxLength = formatter.maxLength;
+      return newValueLength <= maxLength;
+    }, orElse: () {
+      return _formatters.first;
+    });
+    return delegatedFormatter.formatEditUpdate(oldValue, newValue);
+  }
+}

--- a/lib/compound_formatters/compound_formatter.dart
+++ b/lib/compound_formatters/compound_formatter.dart
@@ -1,11 +1,11 @@
 import 'package:brasil_fields/interfaces/compoundable_formatter.dart';
 import 'package:flutter/services.dart';
 
-/// Combines two or more [Formatter] instances such that
-/// it's possible to interpolate from the actual to the next
+/// Combina dois ous mais instâncias de [Formatter] de forma que
+/// seja possível interpolar de um para outro
 class CompoundFormatter extends TextInputFormatter {
-  /// Stores a series of [CompoundableFormatter] instances which are chained
-  /// in the same order as they are positioned in the List
+  /// Guarda uma lista de [CompoundableFormatter] que são encadeados
+  /// na mesma ordem em que estão posicionados na lista
   final List<CompoundableFormatter> _formatters;
 
   CompoundFormatter(this._formatters)

--- a/lib/compound_formatters/cpf_to_cpnj_formatter.dart
+++ b/lib/compound_formatters/cpf_to_cpnj_formatter.dart
@@ -1,0 +1,9 @@
+import 'package:brasil_fields/brasil_fields.dart';
+
+class CPFToCNPJFormatter extends CompoundFormatter {
+  CPFToCNPJFormatter()
+      : super([
+          CpfInputFormatter(),
+          CnpjInputFormatter(),
+        ]);
+}

--- a/lib/formatter/cnpj_input_formatter.dart
+++ b/lib/formatter/cnpj_input_formatter.dart
@@ -1,9 +1,11 @@
+import 'package:brasil_fields/interfaces/compoundable_formatter.dart';
 import 'package:flutter/services.dart';
 
 /// Formata o valor do campo com a mascara de CNPJ ( 99.999.999/9999-99 ).
-class CnpjInputFormatter extends TextInputFormatter {
+class CnpjInputFormatter extends TextInputFormatter
+    implements CompoundableFormatter {
   /// Define o tamanho máximo do campo.
-  final int maxLength = 14;
+  int get maxLength => 14;
 
   @override
   TextEditingValue formatEditUpdate(

--- a/lib/formatter/cpf_input_formatter.dart
+++ b/lib/formatter/cpf_input_formatter.dart
@@ -1,9 +1,12 @@
+import 'package:brasil_fields/interfaces/compoundable_formatter.dart';
 import 'package:flutter/services.dart';
 
 /// Formata o valor do campo com a mascara de CPF ( XXX.XXX.XXX-XX ).
-class CpfInputFormatter extends TextInputFormatter {
+class CpfInputFormatter extends TextInputFormatter
+    implements CompoundableFormatter {
   /// Define o tamanho máximo do campo.
-  final int maxLength = 11;
+  @override
+  int get maxLength => 11;
 
   @override
   TextEditingValue formatEditUpdate(

--- a/lib/interfaces/compoundable_formatter.dart
+++ b/lib/interfaces/compoundable_formatter.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/services.dart';
+
+/// Defines a Formatter which can be combined with another one
+/// to make the transition from one to another possible
+/// Used in [CompoundableFormatter]
+abstract class CompoundableFormatter extends TextInputFormatter {
+  /// Returns the maximum length from the Formatter
+  int get maxLength;
+}

--- a/lib/interfaces/compoundable_formatter.dart
+++ b/lib/interfaces/compoundable_formatter.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/services.dart';
 
-/// Defines a Formatter which can be combined with another one
-/// to make the transition from one to another possible
-/// Used in [CompoundableFormatter]
+/// Define um [TextInputFormatter] que pode ser combinado com outros
+/// para que seja possível interpolar de um para outro
+/// Usado em [CompoundableFormatter]
 abstract class CompoundableFormatter extends TextInputFormatter {
-  /// Returns the maximum length from the Formatter
+  /// Tamanho máximo do Formatter
   int get maxLength;
 }

--- a/test/brasil_fields_test.dart
+++ b/test/brasil_fields_test.dart
@@ -1,4 +1,5 @@
 import 'package:brasil_fields/brasil_fields.dart';
+import 'package:brasil_fields/compound_formatters/cpf_to_cpnj_formatter.dart';
 import 'package:brasil_fields/formatter/cartao_bancario_input_formatter.dart';
 import 'package:brasil_fields/formatter/cnpj_input_formatter.dart';
 import 'package:brasil_fields/formatter/hora_input_formatter.dart';
@@ -135,5 +136,46 @@ void main() {
     await tester.pumpWidget(boilerplate(PesoInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), '1043');
     expect(textController.text, '104,3');
+  });
+
+  testWidgets('Compound of CPF and CPNJ', (WidgetTester tester) async {
+    final textController = TextEditingController();
+    final formatter = CompoundFormatter([
+      CpfInputFormatter(),
+      CnpjInputFormatter(),
+    ]);
+
+    // Whe expect the results to be as follows:
+    // '123.456.789-00'      // CPF
+    // '12.345.678/9000-99'  // CPNJ
+
+    await tester.pumpWidget(boilerplate(formatter, textController));
+    await tester.enterText(find.byType(TextField), '12345678900');
+    expect(textController.text, '123.456.789-00');
+    await tester.enterText(find.byType(TextField), '123456789000');
+    expect(textController.text, '12.345.678/9000');
+    await tester.enterText(find.byType(TextField), '1234567890009');
+    expect(textController.text, '12.345.678/9000-9');
+    await tester.enterText(find.byType(TextField), '12345678900099');
+    expect(textController.text, '12.345.678/9000-99');
+  });
+
+  testWidgets('CPFToCPNJFormatter', (WidgetTester tester) async {
+    final textController = TextEditingController();
+    final formatter = CPFToCNPJFormatter();
+
+    // Whe expect the results to be as follows:
+    // '123.456.789-00'      // CPF
+    // '12.345.678/9000-99'  // CPNJ
+
+    await tester.pumpWidget(boilerplate(formatter, textController));
+    await tester.enterText(find.byType(TextField), '12345678900');
+    expect(textController.text, '123.456.789-00');
+    await tester.enterText(find.byType(TextField), '123456789000');
+    expect(textController.text, '12.345.678/9000');
+    await tester.enterText(find.byType(TextField), '1234567890009');
+    expect(textController.text, '12.345.678/9000-9');
+    await tester.enterText(find.byType(TextField), '12345678900099');
+    expect(textController.text, '12.345.678/9000-99');
   });
 }

--- a/test/brasil_fields_test.dart
+++ b/test/brasil_fields_test.dart
@@ -145,7 +145,7 @@ void main() {
       CnpjInputFormatter(),
     ]);
 
-    // Whe expect the results to be as follows:
+    // Esperamos os resultados no seguinte formato:
     // '123.456.789-00'      // CPF
     // '12.345.678/9000-99'  // CPNJ
 
@@ -164,7 +164,7 @@ void main() {
     final textController = TextEditingController();
     final formatter = CPFToCNPJFormatter();
 
-    // Whe expect the results to be as follows:
+    // Esperamos os resultados no seguinte formato:
     // '123.456.789-00'      // CPF
     // '12.345.678/9000-99'  // CPNJ
 


### PR DESCRIPTION
Agora é possível "concatenar" dois ou mais _Formatters_ e interpolar entre eles conforme o tamanho da String que o usuário digita. Relacionado ao issue #10.

```dart
// Agora é possível concatenar um ou mais formatters, de forma que a ordem 
// deve ser crescente em relação ao tamanho.
// (dependendo do tamanho do input o formater a ser usado é o próximo)
final formatter = CompoundFormatter([
      CpfInputFormatter(),
      CnpjInputFormatter(),
]);

// Ou usar o helper:
final formatter = CPFToCNPJFormatter();
```