### PR TITLE
Export validators.dart

### DIFF
--- a/lib/brasil_fields.dart
+++ b/lib/brasil_fields.dart
@@ -20,3 +20,4 @@ export 'src/modelos/regioes.dart';
 export 'src/modelos/semana.dart';
 export 'src/util/util_data.dart';
 export 'src/util/util_brasil_fields.dart';
+export 'src/validators/validators.dart';


### PR DESCRIPTION
Export validators.dart to allow using CPFValidator and CNPJValidator directly.