### PR TITLE
Atualização da documentação para novos métodos de UtilBrasilFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ A classe `UtilData` possui métodos que facilitam obter o valor de um objeto `Da
 
 A classe `UtilBrasilFields` possui métodos que facilitam obter os valores CEP, KM, CPF e CPNJ já formatados:
 
+- `UtilBrasilFields.gerarCPF(bool? useFormat)` (Gera um CPF aleatório com ou sem formatação)
+- `UtilBrasilFields.gerarCNPJ(bool? useFormat)` (Gera um CNPJ aleatório com ou sem formatação)
 - `UtilBrasilFields.obterCpf('11122233344')` (111.222.333-44)
 - `UtilBrasilFields.obterCnpj('11222333444455')` (11.222.333/4444-55)
 - `UtilBrasilFields.obterCep('11222333')` (11.222-333)
@@ -120,15 +122,15 @@ A classe `UtilBrasilFields` possui métodos que facilitam obter os valores CEP, 
 - `UtilBrasilFields.obterTelefone('(00) 99999-8877', mascara: false)` (00999998877)
 - `UtilBrasilFields.obterTelefone('999998877', ddd: false)` (99999-8877)
 - `UtilBrasilFields.obterTelefone('99999-8877', ddd: false, mascara: false)` (999998877)
-- `UtilBrasilFields.obterDDD('00999998877')` (00)
+- `UtilBrasilFields.obterReal` (R$ 50.000,00 ou 50.000,00)
 - `UtilBrasilFields.obterReal(85437107.04)` (R$ 85.437.107,04)
 - `UtilBrasilFields.obterReal(85437107.04, moeda: false)` (85.437.107,04)
 - `UtilBrasilFields.obterReal(85437107.04, moeda: false, decimal: 0)` (85.437.107)
+- `UtilBrasilFields.obterDDD('00999998877')` (00)
+- `UtilBrasilFields.obterKM(999999)` (999.999)
 - `UtilBrasilFields.removeCaracteres` (remove caracteres especiais)
 - `UtilBrasilFields.removerSimboloMoeda` (remove o R$)
 - `UtilBrasilFields.converterMoedaParaDouble` (remove o R$ e retorna um double)
-- `UtilBrasilFields.obterReal` (R$ 50.000,00 ou 50.000,00)
-- `UtilBrasilFields.obterKM(999999)` (999.999)
 
 A classe `UtilBrasilFields` possui métodos para validar CPF e CNPJ: `isCPFValido` e `isCNPJValido`.
 


### PR DESCRIPTION
Os métodos ```gerarCPF()``` e ```gerarCNPJ()``` não existem na documentação e podem passar despercebido para quem necessita do recurso.

Atualizei a lista dos métodos de UtilBrasilFields, afim de tornar mais organizado e completo para quem lê.

É um prazer poder contribuir mesmo que de maneira simples com este package, pois ele é muito útil para desenvolvedores do Brasil. Parabéns pelo projeto!