### PR TITLE
Correção de bug na formatação de CPF + Criação de novo parâmetro

### DIFF
--- a/lib/src/formatters/cpf_input_formatter.dart
+++ b/lib/src/formatters/cpf_input_formatter.dart
@@ -1,42 +1,56 @@
-import 'package:brasil_fields/src/interfaces/compoundable_formatter.dart';
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/services.dart';
 
+import 'package:brasil_fields/src/interfaces/compoundable_formatter.dart';
+
 /// Formata o valor do campo com a mascara de CPF: `XXX.XXX.XXX-XX`
-class CpfInputFormatter extends TextInputFormatter
-    implements CompoundableFormatter {
+class CpfInputFormatter extends TextInputFormatter implements CompoundableFormatter {
+  final bool deleteSeparatorsAutomatically;
+  CpfInputFormatter({this.deleteSeparatorsAutomatically = true});
+
   // Define o tamanho máximo do campo.
   @override
-  int get maxLength => 11;
+  int get maxLength => 14;
 
   @override
-  TextEditingValue formatEditUpdate(
-      TextEditingValue oldValue, TextEditingValue newValue) {
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
     // verifica o tamanho máximo do campo
     if (newValue.text.length > maxLength) return oldValue;
 
-    var posicaoCursor = newValue.selection.end;
+    // valida o parâmetro que indica se deve remover os separadores automaticamente ao apagar um número
+    if (newValue.text.length < oldValue.text.length) {
+      if (deleteSeparatorsAutomatically == true) {
+        if (newValue.text.endsWith('.') || newValue.text.endsWith('-')) {
+          return newValue.copyWith(
+            text: newValue.text.substring(0, newValue.text.length - 1),
+            selection: TextSelection.collapsed(offset: newValue.selection.end - 1),
+          );
+        }
+        return newValue;
+      } else {
+        return newValue;
+      }
+    }
+
     var substrIndex = 0;
     final valorFinal = StringBuffer();
 
     if (newValue.text.length >= 4) {
       valorFinal.write('${newValue.text.substring(0, substrIndex = 3)}.');
-      if (newValue.selection.end >= 3) posicaoCursor++;
     }
     if (newValue.text.length >= 7) {
-      valorFinal.write('${newValue.text.substring(3, substrIndex = 6)}.');
-      if (newValue.selection.end >= 6) posicaoCursor++;
+      valorFinal.write('${newValue.text.substring(4, substrIndex = 7)}.');
     }
-    if (newValue.text.length >= 10) {
-      valorFinal.write('${newValue.text.substring(6, substrIndex = 9)}-');
-      if (newValue.selection.end >= 9) posicaoCursor++;
+    if (newValue.text.length >= 11) {
+      valorFinal.write('${newValue.text.substring(8, substrIndex = 11)}-');
     }
     if (newValue.text.length >= substrIndex) {
-      valorFinal.write(newValue.text.substring(substrIndex));
+      valorFinal.write(newValue.text.substring(substrIndex).replaceAll('.', '').replaceAll('-', ''));
     }
 
     return TextEditingValue(
       text: valorFinal.toString(),
-      selection: TextSelection.collapsed(offset: posicaoCursor),
+      selection: TextSelection.collapsed(offset: valorFinal.length),
     );
   }
 }

--- a/lib/src/formatters/cpf_input_formatter.dart
+++ b/lib/src/formatters/cpf_input_formatter.dart
@@ -1,7 +1,5 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
-import 'package:flutter/services.dart';
-
 import 'package:brasil_fields/src/interfaces/compoundable_formatter.dart';
+import 'package:flutter/services.dart';
 
 /// Formata o valor do campo com a mascara de CPF: `XXX.XXX.XXX-XX`
 class CpfInputFormatter extends TextInputFormatter implements CompoundableFormatter {
@@ -13,7 +11,8 @@ class CpfInputFormatter extends TextInputFormatter implements CompoundableFormat
   int get maxLength => 14;
 
   @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue, TextEditingValue newValue) {
     // verifica o tamanho máximo do campo
     if (newValue.text.length > maxLength) return oldValue;
 

--- a/test/cpf_test.dart
+++ b/test/cpf_test.dart
@@ -1,4 +1,5 @@
-import 'package:brasil_fields/brasil_fields.dart';
+import 'package:brasil_fields/src/formatters/cpf_input_formatter.dart';
+import 'package:brasil_fields/src/validators/validators.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,11 +10,28 @@ void main() {
     expect(CPFValidator.isValid('35999906032'), true);
     expect(CPFValidator.isValid('35999906031'), false);
     expect(CPFValidator.isValid('033461671002'), false);
-    expect(CPFValidator.isValid('03346teste1671002@mail', stripBeforeValidation: false), false);
-    expect(CPFValidator.isValid('57abc803.6586-52', stripBeforeValidation: false), false);
+    expect(
+        CPFValidator.isValid('03346teste1671002@mail',
+            stripBeforeValidation: false),
+        false);
+    expect(
+        CPFValidator.isValid('57abc803.6586-52', stripBeforeValidation: false),
+        false);
     expect(CPFValidator.isValid('03.3461.67100-2'), false);
 
-    var blockList = <String>['00000000000', '11111111111', '22222222222', '33333333333', '44444444444', '55555555555', '66666666666', '77777777777', '88888888888', '99999999999', '12345678909'];
+    var blockList = <String>[
+      '00000000000',
+      '11111111111',
+      '22222222222',
+      '33333333333',
+      '44444444444',
+      '55555555555',
+      '66666666666',
+      '77777777777',
+      '88888888888',
+      '99999999999',
+      '12345678909'
+    ];
 
     for (var cpf in blockList) {
       expect(CPFValidator.isValid(cpf), false);

--- a/test/cpf_test.dart
+++ b/test/cpf_test.dart
@@ -1,4 +1,5 @@
-import 'package:brasil_fields/src/validators/validators.dart';
+import 'package:brasil_fields/brasil_fields.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -8,28 +9,11 @@ void main() {
     expect(CPFValidator.isValid('35999906032'), true);
     expect(CPFValidator.isValid('35999906031'), false);
     expect(CPFValidator.isValid('033461671002'), false);
-    expect(
-        CPFValidator.isValid('03346teste1671002@mail',
-            stripBeforeValidation: false),
-        false);
-    expect(
-        CPFValidator.isValid('57abc803.6586-52', stripBeforeValidation: false),
-        false);
+    expect(CPFValidator.isValid('03346teste1671002@mail', stripBeforeValidation: false), false);
+    expect(CPFValidator.isValid('57abc803.6586-52', stripBeforeValidation: false), false);
     expect(CPFValidator.isValid('03.3461.67100-2'), false);
 
-    var blockList = <String>[
-      '00000000000',
-      '11111111111',
-      '22222222222',
-      '33333333333',
-      '44444444444',
-      '55555555555',
-      '66666666666',
-      '77777777777',
-      '88888888888',
-      '99999999999',
-      '12345678909'
-    ];
+    var blockList = <String>['00000000000', '11111111111', '22222222222', '33333333333', '44444444444', '55555555555', '66666666666', '77777777777', '88888888888', '99999999999', '12345678909'];
 
     for (var cpf in blockList) {
       expect(CPFValidator.isValid(cpf), false);
@@ -53,5 +37,18 @@ void main() {
 
   test('Test CPF strip', () {
     expect(CPFValidator.strip('334.616.710-02'), '33461671002');
+  });
+
+  test('Test CpfInputFormatter', () {
+    expect(
+      CpfInputFormatter().formatEditUpdate(
+        const TextEditingValue(text: '334.616.71'), // oldValue
+        const TextEditingValue(text: '334.616.710'), // newValue
+      ),
+      const TextEditingValue(
+        text: '334.616.710-', // newValue formatted
+        selection: TextSelection.collapsed(offset: 12),
+      ),
+    );
   });
 }


### PR DESCRIPTION
Ao utilizar o formatador de CPF CpfInputFormatter(), percebi que o mesmo não estava se portando de maneira correta.
Fiz o teste utilizando iOS 17, com a versão 1.14.3 do package, e o comportamento foi o seguinte:

![brasil_fields_bug](https://github.com/flutterbootcamp/brasil_fields/assets/39710307/d0b73531-6f46-4d11-a587-f9dc4612b6a9)

Efetuei a correção, e também já criei um teste, o qual pode ser revisado também, case seja necessário.

Aproveitando a correção, tomei a liberdade de adicionar um parâmetro nomeado opcional no formatter:

`bool deleteSeparatorsAutomatically = true;`

Ele é opcional para não gerar nenhum break change, e o objetivo é controlar o seguinte caso:
`Caso seja true(default): irá apagar os delimitadores (.) (-) automaticamente ao apagar os caracteres.`
`Caso seja false: NÃO irá apagar os delimitadores (.) (-) automaticamente ao apagar os caracteres.`

Caso o PR seja aprovado, eu me disponho a atualizar a documentação também.

Atenciosamente,
Adilson Junior.