### PR TITLE
Certidão de Nasicmento Modelo Novo + teste

### DIFF
--- a/lib/brasil_fields.dart
+++ b/lib/brasil_fields.dart
@@ -5,6 +5,7 @@ export 'src/formatters/cartao_bancario_input_formatter.dart';
 export 'src/formatters/centavos_input_formatter.dart';
 export 'src/formatters/cep_input_formatter.dart';
 export 'src/formatters/cest_input_formatter.dart';
+export 'src/formatters/cert_nascimento_input_formatter.dart';
 export 'src/formatters/cnpj_input_formatter.dart';
 export 'src/formatters/cns_formatter.dart';
 export 'src/formatters/compound_formatters/cpf_ou_cpnj_formatter.dart';

--- a/lib/src/formatters/cert_nascimento_input_formatter.dart
+++ b/lib/src/formatters/cert_nascimento_input_formatter.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+
+/// Formata o valor do campo com a mascara de Certidão de Nascimento: `XXXXXX XX XX XXXX X XXXXX XXX XXXXXXX XX`
+class CertNascimentoInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    // verifica o tamanho máximo do campo
+    if (newValue.text.length > 32) return oldValue;
+
+    var posicaoCursor = newValue.selection.end;
+    var substrIndex = 0;
+    final valorFinal = StringBuffer();
+
+    if (newValue.text.length >= 7) {
+      valorFinal.write('${newValue.text.substring(0, substrIndex = 6)} ');
+      if (newValue.selection.end >= 6) posicaoCursor++;
+    }
+    if (newValue.text.length >= 9) {
+      valorFinal.write('${newValue.text.substring(6, substrIndex = 8)} ');
+      if (newValue.selection.end >= 8) posicaoCursor++;
+    }
+    if (newValue.text.length >= 11) {
+      valorFinal.write('${newValue.text.substring(8, substrIndex = 10)} ');
+      if (newValue.selection.end >= 10) posicaoCursor++;
+    }
+    if (newValue.text.length >= 15) {
+      valorFinal.write('${newValue.text.substring(10, substrIndex = 14)} ');
+      if (newValue.selection.end >= 14) posicaoCursor++;
+    }
+    if (newValue.text.length >= 16) {
+      valorFinal.write('${newValue.text.substring(14, substrIndex = 15)} ');
+      if (newValue.selection.end >= 15) posicaoCursor++;
+    }
+    if (newValue.text.length >= 21) {
+      valorFinal.write('${newValue.text.substring(15, substrIndex = 20)} ');
+      if (newValue.selection.end >= 20) posicaoCursor++;
+    }
+    if (newValue.text.length >= 24) {
+      valorFinal.write('${newValue.text.substring(20, substrIndex = 23)} ');
+      if (newValue.selection.end >= 23) posicaoCursor++;
+    }
+    if (newValue.text.length >= 31) {
+      valorFinal.write('${newValue.text.substring(23, substrIndex = 30)} ');
+      if (newValue.selection.end >= 30) posicaoCursor++;
+    }
+    if (newValue.text.length >= substrIndex) {
+      valorFinal.write(newValue.text.substring(substrIndex));
+    }
+
+    return TextEditingValue(
+      text: valorFinal.toString(),
+      selection: TextSelection.collapsed(offset: posicaoCursor),
+    );
+  }
+}

--- a/test/brasil_fields_test.dart
+++ b/test/brasil_fields_test.dart
@@ -1,5 +1,4 @@
 import 'package:brasil_fields/brasil_fields.dart';
-import 'package:brasil_fields/src/formatters/cert_nascimento_input_formatter.dart';
 import 'package:brasil_fields/src/formatters/compound_formatters/compound_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/test/brasil_fields_test.dart
+++ b/test/brasil_fields_test.dart
@@ -47,12 +47,14 @@ void main() {
   testWidgets('TelefoneInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
 
-    await tester.pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
+    await tester
+        .pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '9912345678');
     expect(textController.text, '(99) 1234-5678');
 
-    await tester.pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
+    await tester
+        .pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), '00987654321');
 
     expect(textController.text, '(00) 98765-4321');
@@ -68,7 +70,8 @@ void main() {
     await tester.enterText(find.byType(TextField), '12345678');
     expect(textController.text, '12.345-678');
 
-    await tester.pumpWidget(boilerplate(CepInputFormatter(ponto: false), textController));
+    await tester.pumpWidget(
+        boilerplate(CepInputFormatter(ponto: false), textController));
 
     await tester.enterText(find.byType(TextField), '12345678');
     expect(textController.text, '12345-678');
@@ -101,7 +104,8 @@ void main() {
   testWidgets('RealInputFormatter + moeda', (WidgetTester tester) async {
     final textController = TextEditingController();
 
-    await tester.pumpWidget(boilerplate(RealInputFormatter(moeda: true), textController));
+    await tester.pumpWidget(
+        boilerplate(RealInputFormatter(moeda: true), textController));
 
     await tester.enterText(find.byType(TextField), '1256780');
     expect(textController.text, 'R\$ 1.256.780');
@@ -124,7 +128,8 @@ void main() {
 
   testWidgets('CentavosInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester.pumpWidget(boilerplate(CentavosInputFormatter(), textController));
+    await tester
+        .pumpWidget(boilerplate(CentavosInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '12567');
     expect(textController.text, '125,67');
@@ -142,7 +147,8 @@ void main() {
   testWidgets('CentavosInputFormatter 3 decimais', (WidgetTester tester) async {
     final textController = TextEditingController();
 
-    await tester.pumpWidget(boilerplate(CentavosInputFormatter(casasDecimais: 3), textController));
+    await tester.pumpWidget(
+        boilerplate(CentavosInputFormatter(casasDecimais: 3), textController));
 
     await tester.enterText(find.byType(TextField), '125678');
     expect(textController.text, '125,678');
@@ -175,7 +181,7 @@ void main() {
     await tester.enterText(find.byType(TextField), '11111122334444566666777888888899');
     expect(textController.text, '111111 22 33 4444 5 66666 777 8888888 99');
   });
-
+    
   testWidgets('HoraInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
     await tester.pumpWidget(boilerplate(HoraInputFormatter(), textController));
@@ -186,14 +192,16 @@ void main() {
 
   testWidgets('CartaoBancarioInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester.pumpWidget(boilerplate(CartaoBancarioInputFormatter(), textController));
+    await tester.pumpWidget(
+        boilerplate(CartaoBancarioInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '4040121298987373');
     expect(textController.text, '4040 1212 9898 7373');
   });
   testWidgets('ValidadeCartaoInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester.pumpWidget(boilerplate(ValidadeCartaoInputFormatter(), textController));
+    await tester.pumpWidget(
+        boilerplate(ValidadeCartaoInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '1223');
     expect(textController.text, '12/23');
@@ -201,7 +209,8 @@ void main() {
 
   testWidgets('TemperaturaInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester.pumpWidget(boilerplate(TemperaturaInputFormatter(), textController));
+    await tester
+        .pumpWidget(boilerplate(TemperaturaInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '176');
     expect(textController.text, '17,6');
@@ -223,11 +232,13 @@ void main() {
     final textController = TextEditingController();
 
     // testa toUpperCase
-    await tester.pumpWidget(boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
+    await tester.pumpWidget(
+        boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), 'abc');
     expect(textController.text, 'ABC');
 
-    await tester.pumpWidget(boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
+    await tester.pumpWidget(
+        boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), 'abc-1234');
     expect(textController.text, 'ABC-1234');
   });

--- a/test/brasil_fields_test.dart
+++ b/test/brasil_fields_test.dart
@@ -1,4 +1,5 @@
 import 'package:brasil_fields/brasil_fields.dart';
+import 'package:brasil_fields/src/formatters/cert_nascimento_input_formatter.dart';
 import 'package:brasil_fields/src/formatters/compound_formatters/compound_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -46,14 +47,12 @@ void main() {
   testWidgets('TelefoneInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
 
-    await tester
-        .pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
+    await tester.pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '9912345678');
     expect(textController.text, '(99) 1234-5678');
 
-    await tester
-        .pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
+    await tester.pumpWidget(boilerplate(TelefoneInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), '00987654321');
 
     expect(textController.text, '(00) 98765-4321');
@@ -69,8 +68,7 @@ void main() {
     await tester.enterText(find.byType(TextField), '12345678');
     expect(textController.text, '12.345-678');
 
-    await tester.pumpWidget(
-        boilerplate(CepInputFormatter(ponto: false), textController));
+    await tester.pumpWidget(boilerplate(CepInputFormatter(ponto: false), textController));
 
     await tester.enterText(find.byType(TextField), '12345678');
     expect(textController.text, '12345-678');
@@ -103,8 +101,7 @@ void main() {
   testWidgets('RealInputFormatter + moeda', (WidgetTester tester) async {
     final textController = TextEditingController();
 
-    await tester.pumpWidget(
-        boilerplate(RealInputFormatter(moeda: true), textController));
+    await tester.pumpWidget(boilerplate(RealInputFormatter(moeda: true), textController));
 
     await tester.enterText(find.byType(TextField), '1256780');
     expect(textController.text, 'R\$ 1.256.780');
@@ -127,8 +124,7 @@ void main() {
 
   testWidgets('CentavosInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester
-        .pumpWidget(boilerplate(CentavosInputFormatter(), textController));
+    await tester.pumpWidget(boilerplate(CentavosInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '12567');
     expect(textController.text, '125,67');
@@ -146,8 +142,7 @@ void main() {
   testWidgets('CentavosInputFormatter 3 decimais', (WidgetTester tester) async {
     final textController = TextEditingController();
 
-    await tester.pumpWidget(
-        boilerplate(CentavosInputFormatter(casasDecimais: 3), textController));
+    await tester.pumpWidget(boilerplate(CentavosInputFormatter(casasDecimais: 3), textController));
 
     await tester.enterText(find.byType(TextField), '125678');
     expect(textController.text, '125,678');
@@ -173,6 +168,14 @@ void main() {
     expect(textController.text, '01/01/1900');
   });
 
+  testWidgets('CertNascimentoFormatter', (WidgetTester tester) async {
+    final textController = TextEditingController();
+    await tester.pumpWidget(boilerplate(CertNascimentoInputFormatter(), textController));
+
+    await tester.enterText(find.byType(TextField), '11111122334444566666777888888899');
+    expect(textController.text, '111111 22 33 4444 5 66666 777 8888888 99');
+  });
+
   testWidgets('HoraInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
     await tester.pumpWidget(boilerplate(HoraInputFormatter(), textController));
@@ -183,16 +186,14 @@ void main() {
 
   testWidgets('CartaoBancarioInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester.pumpWidget(
-        boilerplate(CartaoBancarioInputFormatter(), textController));
+    await tester.pumpWidget(boilerplate(CartaoBancarioInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '4040121298987373');
     expect(textController.text, '4040 1212 9898 7373');
   });
   testWidgets('ValidadeCartaoInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester.pumpWidget(
-        boilerplate(ValidadeCartaoInputFormatter(), textController));
+    await tester.pumpWidget(boilerplate(ValidadeCartaoInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '1223');
     expect(textController.text, '12/23');
@@ -200,8 +201,7 @@ void main() {
 
   testWidgets('TemperaturaInputFormatter', (WidgetTester tester) async {
     final textController = TextEditingController();
-    await tester
-        .pumpWidget(boilerplate(TemperaturaInputFormatter(), textController));
+    await tester.pumpWidget(boilerplate(TemperaturaInputFormatter(), textController));
 
     await tester.enterText(find.byType(TextField), '176');
     expect(textController.text, '17,6');
@@ -223,13 +223,11 @@ void main() {
     final textController = TextEditingController();
 
     // testa toUpperCase
-    await tester.pumpWidget(
-        boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
+    await tester.pumpWidget(boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), 'abc');
     expect(textController.text, 'ABC');
 
-    await tester.pumpWidget(
-        boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
+    await tester.pumpWidget(boilerplatePlacaVeiculo(PlacaVeiculoInputFormatter(), textController));
     await tester.enterText(find.byType(TextField), 'abc-1234');
     expect(textController.text, 'ABC-1234');
   });


### PR DESCRIPTION
Foi adicionado o input formatter para [certidão de nascimento modelo novo](https://portaleduca.educacao.go.gov.br/suporte_ti/modelo-novo-de-certidao-de-nascimento-ou-casamento/).

Exemplo:
`11111101552024100799253046111008`
`111111 01 55 2024 1 00799 253 0461110 08`
