### PR TITLE
Adiciona `obterCnpjInscricao`, `obterCnpjOrdem` e `obterCnpjDiv`

### DIFF
--- a/lib/src/util/util_brasil_fields.dart
+++ b/lib/src/util/util_brasil_fields.dart
@@ -115,7 +115,7 @@ class UtilBrasilFields {
   /// `true`: inscrição terá o formato `XX.YYY.ZZZ`
   ///
   /// `false`: inscrição terá o formato `XXYYYZZZ`
-  static String obterInscricaoCnpj(String cnpj, {bool useFormat = false}) {
+  static String obterCnpjInscricao(String cnpj, {bool useFormat = false}) {
     assert(isCNPJValido(cnpj), 'CNPJ inválido!');
     return useFormat
         ? CNPJValidator.format(cnpj).substring(0, 10)
@@ -126,7 +126,7 @@ class UtilBrasilFields {
   ///
   /// A ordem do CNPJ são os 4 dígitos após a barra. Essa parte representa se o
   /// estabelecimento é matriz ou filial (0001 = matriz, 0002 = filial).
-  static String obterOrdemCnpj(String cnpj) {
+  static String obterCnpjOrdem(String cnpj) {
     assert(isCNPJValido(cnpj), 'CNPJ inválido!');
     return CNPJValidator.strip(cnpj).substring(8, 12);
   }
@@ -134,7 +134,7 @@ class UtilBrasilFields {
   /// Retorna os dígitos verificadores do [cnpj] informado.
   ///
   /// Os dígitos verificadores são os dois últimos números do CNPJ.
-  static String obterDivCnpj(String cnpj) {
+  static String obterCnpjDiv(String cnpj) {
     assert(isCNPJValido(cnpj), 'CNPJ inválido!');
     return CNPJValidator.strip(cnpj).substring(12);
   }

--- a/lib/src/util/util_brasil_fields.dart
+++ b/lib/src/util/util_brasil_fields.dart
@@ -108,6 +108,37 @@ class UtilBrasilFields {
     return CNPJValidator.format(cnpj);
   }
 
+  /// Retorna os dígitos da inscrição do [cnpj] informado.
+  ///
+  /// Formatado ou não formatado, baseado no parâmetro `useFormat`:
+  ///
+  /// `true`: inscrição terá o formato `XX.YYY.ZZZ`
+  ///
+  /// `false`: inscrição terá o formato `XXYYYZZZ`
+  static String obterInscricaoCnpj(String cnpj, {bool useFormat = false}) {
+    assert(isCNPJValido(cnpj), 'CNPJ inválido!');
+    return useFormat
+        ? CNPJValidator.format(cnpj).substring(0, 10)
+        : CNPJValidator.strip(cnpj).substring(0, 8);
+  }
+
+  /// Retorna os dígitos da ordem do [cnpj] informado.
+  ///
+  /// A ordem do CNPJ são os 4 dígitos após a barra. Essa parte representa se o
+  /// estabelecimento é matriz ou filial (0001 = matriz, 0002 = filial).
+  static String obterOrdemCnpj(String cnpj) {
+    assert(isCNPJValido(cnpj), 'CNPJ inválido!');
+    return CNPJValidator.strip(cnpj).substring(8, 12);
+  }
+
+  /// Retorna os dígitos verificadores do [cnpj] informado.
+  ///
+  /// Os dígitos verificadores são os dois últimos números do CNPJ.
+  static String obterDivCnpj(String cnpj) {
+    assert(isCNPJValido(cnpj), 'CNPJ inválido!');
+    return CNPJValidator.strip(cnpj).substring(12);
+  }
+
   /// Retorna o número real informado, utilizando a máscara: `R$ 50.000,00` ou `50.000,00`
   static String obterReal(double value, {bool moeda = true, int decimal = 2}) {
     bool isNegative = false;

--- a/test/util_brasil_fields_test.dart
+++ b/test/util_brasil_fields_test.dart
@@ -237,14 +237,14 @@ void main() {
   test('Obter inscrição CNPJ', () {
     const cpnjSemMascara = '34318733000190';
     const cpnjComMascara = '34.318.733/0001-90';
-    expect(UtilBrasilFields.obterInscricaoCnpj(cpnjSemMascara), '34318733');
-    expect(UtilBrasilFields.obterInscricaoCnpj(cpnjComMascara), '34318733');
+    expect(UtilBrasilFields.obterCnpjInscricao(cpnjSemMascara), '34318733');
+    expect(UtilBrasilFields.obterCnpjInscricao(cpnjComMascara), '34318733');
     expect(
-      UtilBrasilFields.obterInscricaoCnpj(cpnjSemMascara, useFormat: true),
+      UtilBrasilFields.obterCnpjInscricao(cpnjSemMascara, useFormat: true),
       '34.318.733',
     );
     expect(
-      UtilBrasilFields.obterInscricaoCnpj(cpnjComMascara, useFormat: true),
+      UtilBrasilFields.obterCnpjInscricao(cpnjComMascara, useFormat: true),
       '34.318.733',
     );
   });
@@ -252,15 +252,15 @@ void main() {
   test('Obter Ordem do CNPJ', () {
     const cpnjSemMascara = '34318733000190';
     const cpnjComMascara = '34.318.733/0001-90';
-    expect(UtilBrasilFields.obterOrdemCnpj(cpnjSemMascara), '0001');
-    expect(UtilBrasilFields.obterOrdemCnpj(cpnjComMascara), '0001');
+    expect(UtilBrasilFields.obterCnpjOrdem(cpnjSemMascara), '0001');
+    expect(UtilBrasilFields.obterCnpjOrdem(cpnjComMascara), '0001');
   });
 
   test('Obter dígitos verificadores do CNPJ', () {
     const cpnjSemMascara = '34318733000190';
     const cpnjComMascara = '34.318.733/0001-90';
-    expect(UtilBrasilFields.obterDivCnpj(cpnjSemMascara), '90');
-    expect(UtilBrasilFields.obterDivCnpj(cpnjComMascara), '90');
+    expect(UtilBrasilFields.obterCnpjDiv(cpnjSemMascara), '90');
+    expect(UtilBrasilFields.obterCnpjDiv(cpnjComMascara), '90');
   });
 
   group('Obter Real', () {

--- a/test/util_brasil_fields_test.dart
+++ b/test/util_brasil_fields_test.dart
@@ -234,6 +234,35 @@ void main() {
     expect(UtilBrasilFields.obterCnpj(cpnjSemMascara), cpnjComMascara);
   });
 
+  test('Obter inscrição CNPJ', () {
+    const cpnjSemMascara = '34318733000190';
+    const cpnjComMascara = '34.318.733/0001-90';
+    expect(UtilBrasilFields.obterInscricaoCnpj(cpnjSemMascara), '34318733');
+    expect(UtilBrasilFields.obterInscricaoCnpj(cpnjComMascara), '34318733');
+    expect(
+      UtilBrasilFields.obterInscricaoCnpj(cpnjSemMascara, useFormat: true),
+      '34.318.733',
+    );
+    expect(
+      UtilBrasilFields.obterInscricaoCnpj(cpnjComMascara, useFormat: true),
+      '34.318.733',
+    );
+  });
+
+  test('Obter Ordem do CNPJ', () {
+    const cpnjSemMascara = '34318733000190';
+    const cpnjComMascara = '34.318.733/0001-90';
+    expect(UtilBrasilFields.obterOrdemCnpj(cpnjSemMascara), '0001');
+    expect(UtilBrasilFields.obterOrdemCnpj(cpnjComMascara), '0001');
+  });
+
+  test('Obter dígitos verificadores do CNPJ', () {
+    const cpnjSemMascara = '34318733000190';
+    const cpnjComMascara = '34.318.733/0001-90';
+    expect(UtilBrasilFields.obterDivCnpj(cpnjSemMascara), '90');
+    expect(UtilBrasilFields.obterDivCnpj(cpnjComMascara), '90');
+  });
+
   group('Obter Real', () {
     test('com moeda (R\$)', () {
       const real = 85437107.04;


### PR DESCRIPTION
### Contexto 

O CNPJ é formado por 14 dígitos e possui uma estrutura numérica que se divide em três blocos:

- **Inscrição**: 8 primeiros dígitos;
- **Identificação de matriz e filiais**: 4 números após a barra;
- **Dígitos verificadores**: 2 últimos dígitos.

### Sugestão

Este PR foi inspirado pela discussão na Issue #85, no qual foi sugerida a criação de métodos que retornam esses valores separadamente. Por isso, foram criados:

- UtilBrasilFields.obterCnpjInscricao
- UtilBrasilFields.obterCnpjOrdem
- UtilBrasilFields.obterCnpjDiv